### PR TITLE
FIX the react warning about input type checked

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -31,6 +31,14 @@ module.exports = function Converter(options) {
     return result;
   });
 
+  // input type="checkbox" checked> => defaultChecked=true>
+  this._converter.listen('lists.after', function(_, text) {
+    var result = text;
+    result = result
+      .replace(new RegExp('(<input type="checkbox".*)" checked>', 'g'), '$1" defaultChecked=true>');
+    return result;
+  });
+
   this._components = Object.assign({}, options && options.components);
 
   function fixClass(element) {


### PR DESCRIPTION
react warns and *removes* the checked attribute from
input type=checkbox when markdown contains task lists.
So this plugin replace `checked` to `defaultChecked=true`
Note, defaultChecked do not work with react, =true is also
needed (react 16.6.3)

Example, before: 
```
< input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;" checked> first line
```

 after: 
```
< input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;" defaultChecked=true> first line
```

React warning:
Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.